### PR TITLE
Add benchmarking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ install:
   - pip install pipenv
   - pipenv install -d
 script:
-  - pytest --cov=spiral
+  - pytest --benchmark-enable --cov=spiral

--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 
 [dev-packages]
 pytest = "*"
+pytest-benchmark = "*"
 pytest-cov = "*"
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1f689d74f30bc47490b1deaeb9f71259df5c203ccba2c46518184727fd5ce92a"
+            "sha256": "b1f2733b4965bdab96f04e22d00894f8824e4fa387e9d1a9372cf94bf88cf294"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -88,6 +88,12 @@
             ],
             "version": "==1.5.3"
         },
+        "py-cpuinfo": {
+            "hashes": [
+                "sha256:6615d4527118d4ea1db4d86dac4340725b3906aa04bf36b7902f7af4425fb25f"
+            ],
+            "version": "==4.0.0"
+        },
         "pytest": {
             "hashes": [
                 "sha256:54713b26c97538db6ff0703a12b19aeaeb60b5e599de542e7fca0ec83b9038e8",
@@ -95,6 +101,14 @@
             ],
             "index": "pypi",
             "version": "==3.5.1"
+        },
+        "pytest-benchmark": {
+            "hashes": [
+                "sha256:185526b10b7cf1804cb0f32ac0653561ef2f233c6e50a9b3d8066a9757e36480",
+                "sha256:3549545f1a051a789d956a4a9b176583cd6b847e621b788471e6c04b7d8d0e3c"
+            ],
+            "index": "pypi",
+            "version": "==3.1.1"
         },
         "pytest-cov": {
             "hashes": [

--- a/tests/visitor/test_deque_visitor.py
+++ b/tests/visitor/test_deque_visitor.py
@@ -1,8 +1,16 @@
 from unittest import TestCase
 from spiral.visitor.deque_visitor import DequeVisitor
+from spiral.traverser import Traverser
 from ..test_traverser import TestTraverser
 
 
 class TestDequeVisitor(TestTraverser.Shared, TestCase):
     def visitor(self):
         return DequeVisitor(self.accumulator.append)
+
+
+def test_deque_visitor_large_matrix(benchmark):
+    matrix = [[i * 20 + j for j in range(0, 20)]
+              for i in range(0, 20)]
+    accumulator = []
+    benchmark(Traverser(matrix).start, DequeVisitor(accumulator.append))

--- a/tests/visitor/test_iterative_visited.py
+++ b/tests/visitor/test_iterative_visited.py
@@ -1,8 +1,16 @@
 from unittest import TestCase
 from spiral.visitor.iterative_visitor import IterativeVisitor
+from spiral.traverser import Traverser
 from ..test_traverser import TestTraverser
 
 
 class TestIterativeVisited(TestTraverser.Shared, TestCase):
     def visitor(self):
         return IterativeVisitor(self.accumulator.append)
+
+
+def test_iterative_visitor_large_matrix(benchmark):
+    matrix = [[i * 20 + j for j in range(0, 20)]
+              for i in range(0, 20)]
+    accumulator = []
+    benchmark(Traverser(matrix).start, IterativeVisitor(accumulator.append))

--- a/tests/visitor/test_margin_visitor.py
+++ b/tests/visitor/test_margin_visitor.py
@@ -1,8 +1,16 @@
 from unittest import TestCase
 from spiral.visitor.margin_visitor import MarginVisitor
+from spiral.traverser import Traverser
 from ..test_traverser import TestTraverser
 
 
 class TestMarginVisitor(TestTraverser.Shared, TestCase):
     def visitor(self):
         return MarginVisitor(self.accumulator.append)
+
+
+def test_margin_visitor_large_matrix(benchmark):
+    matrix = [[i * 20 + j for j in range(0, 20)]
+              for i in range(0, 20)]
+    accumulator = []
+    benchmark(Traverser(matrix).start, MarginVisitor(accumulator.append))

--- a/tests/visitor/test_recursive_visitor.py
+++ b/tests/visitor/test_recursive_visitor.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 from spiral.visitor.recursive_visitor import RecursiveVisitor
+from spiral.traverser import Traverser
 from ..test_traverser import TestTraverser
 
 
@@ -10,3 +11,10 @@ class TestRecursiveVisitor(TestTraverser.Shared, TestCase):
     # This test is known to fail with a RecursionError
     def test_traverse_large_matrix(self):
         pass
+
+
+def test_recursive_visitor_large_matrix(benchmark):
+    matrix = [[i * 20 + j for j in range(0, 20)]
+              for i in range(0, 20)]
+    accumulator = []
+    benchmark(Traverser(matrix).start, RecursiveVisitor(accumulator.append))


### PR DESCRIPTION
Simply report on the traversal times for each of the visitor types (using a 20x20 matrix).

```
--------------------------------------------------------------------------------------------------- benchmark: 4 tests --------------------------------------------------------------------------------------------------
Name (time in us)                              Min                   Max                  Mean              StdDev                Median                IQR            Outliers         OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_deque_visitor_large_matrix           147.2720 (1.0)      1,569.3510 (1.0)        187.9653 (1.0)       23.7879 (1.0)        185.8370 (1.0)       5.2193 (1.0)       278;448  5,320.1308 (1.0)        4349           1
test_margin_visitor_large_matrix        1,074.5450 (7.30)     1,638.1170 (1.04)     1,514.0232 (8.05)      46.1966 (1.94)     1,516.6010 (8.16)     45.0700 (8.64)        80;15    660.4918 (0.12)        620           1
test_iterative_visitor_large_matrix     2,527.3120 (17.16)    3,842.2200 (2.45)     3,332.0948 (17.73)    147.3448 (6.19)     3,356.2965 (18.06)    62.6740 (12.01)       19;19    300.1115 (0.06)        290           1
test_recursive_visitor_large_matrix     3,079.3190 (20.91)    3,857.7890 (2.46)     3,646.8191 (19.40)    174.2009 (7.32)     3,703.7530 (19.93)    73.5348 (14.09)       29;35    274.2116 (0.05)        217           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```